### PR TITLE
Set suggestions to lowercase to match modern Fortran stdlib style

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -1,9 +1,9 @@
 id = "fortran"
 name = "Fortran"
 description = "Fortran support for Zed"
-version = "0.0.1"
+version = "0.0.2"
 schema_version = 1
-authors = ["Xavier Maruff <xavier.maruff@outlook.com>"]
+authors = ["Xavier Maruff <xavier.maruff@outlook.com>", "John Makowski <brickcodes@proton.me>"]
 repository = "https://github.com/Xavier-Maruff/zed-fortran"
 
 [language_servers.fortls]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ impl zed::Extension for FortranExtension {
 
         Ok(zed::Command {
             command: path,
-            args: vec![],
+            args: vec!["--lowercase_intrinsics".to_string()],
             env: Default::default(),
         })
     }


### PR DESCRIPTION
Modern Fortran stdlib style dictates that all Fortran constructs be written in lowercase, while fortls suggestions are in uppercase by default. This is fixed by adding a single argument to the command, which this merge does.