### PR TITLE
add outline.scm

### DIFF
--- a/languages/fortran/outline.scm
+++ b/languages/fortran/outline.scm
@@ -1,0 +1,9 @@
+(comment) @annotation
+
+(function_statement
+  "function" @context
+  name: (_) @name) @item
+
+(subroutine_statement
+  "subroutine" @context
+  name: (_) @name) @item


### PR DESCRIPTION
I was interested in adding an outline for my longer source files, but I am not really familiar with how to do this. I'd be interested in learning enough to add module statements (and maybe derived type declarations?) as additional outline items. So let me know if you can think of a good resource, and I can update this PR with any progress.